### PR TITLE
[acceptance-test-create-note] Acceptance Test for creating notes and Maven acceptance-tests profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<acceptance.notepad.url>http://localhost:8080</acceptance.notepad.url>
+		<selenium.url>http://localhost:4444/wd/hub</selenium.url>
+        <selenium.browser>firefox</selenium.browser>
 	</properties>
-
+	
 	<scm>
 		<connection>scm:git:git@github.com:jorgeacetozi/notepad.git</connection>
 		<developerConnection>scm:git:git@github.com:jorgeacetozi/notepad.git</developerConnection>
@@ -72,11 +75,39 @@
 			<version>2.2.4</version>
 		</dependency>
 		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-java</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>acceptance-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<includes>
+								<include>**/acceptanceTests/**</include>
+							</includes>
+							<systemPropertyVariables>
+								<selenium.url>${selenium.url}</selenium.url>
+								<selenium.browser>${selenium.browser}</selenium.browser>
+								<acceptance.notepad.url>${acceptance.notepad.url}</acceptance.notepad.url>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>

--- a/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/configuration/AcceptanceTestsConfiguration.java
+++ b/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/configuration/AcceptanceTestsConfiguration.java
@@ -1,0 +1,41 @@
+package com.jorgeacetozi.notepad.acceptanceTests.configuration;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AcceptanceTestsConfiguration {
+	private final static String NOTEPAD_URL = System.getProperty("acceptance.notepad.url", "http://localhost:8080");
+	private final static String SELENIUM_URL = System.getProperty("selenium.url", "http://localhost:4444/wd/hub");
+	private final static String SELENIUM_BROWSER = System.getProperty("selenium.browser", "chrome");
+
+	@Bean(destroyMethod = "quit")
+	public WebDriver webDriver() throws Exception {
+		DesiredCapabilities capabilities = new DesiredCapabilities(SELENIUM_BROWSER, "", Platform.ANY);
+		WebDriverException ex = null;
+		for (int i = 0; i < 10; i++) {
+			try {
+				return new RemoteWebDriver(new URL(SELENIUM_URL), capabilities);
+			} catch (WebDriverException e) {
+				ex = e;
+				System.out.println(String.format("Error connecting to %s: %s. Retrying", SELENIUM_URL, e));
+				Thread.sleep(1000);
+			}
+		}
+		throw ex;
+	}
+
+	@Bean
+	public URI baseUri() throws URISyntaxException {
+		return new URI(NOTEPAD_URL);
+	}
+}

--- a/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/CreateNoteTest.java
+++ b/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/CreateNoteTest.java
@@ -1,0 +1,45 @@
+package com.jorgeacetozi.notepad.acceptanceTests.note;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.jorgeacetozi.notepad.acceptanceTests.configuration.AcceptanceTestsConfiguration;
+import com.jorgeacetozi.notepad.acceptanceTests.note.pageObject.NewNotePage;
+import com.jorgeacetozi.notepad.note.domain.model.Note;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { AcceptanceTestsConfiguration.class })
+public class CreateNoteTest {
+
+	@Autowired
+	private WebDriver driver;
+
+	@Autowired
+	private URI notepadBaseUri;
+
+	private NewNotePage newNotePage;
+	private String newNoteSuccessMessage = "Your note was successfully saved!";
+
+	@Before
+	public void setUp() {
+		driver.get(notepadBaseUri.toString());
+		newNotePage = new NewNotePage(driver);
+	}
+
+	@Test
+	public void shouldCreateNewNote() throws InterruptedException {
+		Note newNote = new Note("Acceptance Test", "Creating note from the acceptance test");
+		newNotePage.create(newNote);
+		assertThat(newNotePage.getMessage(), equalTo(newNoteSuccessMessage));
+	}
+}

--- a/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/pageObject/NewNotePage.java
+++ b/src/test/java/com/jorgeacetozi/notepad/acceptanceTests/note/pageObject/NewNotePage.java
@@ -1,0 +1,49 @@
+package com.jorgeacetozi.notepad.acceptanceTests.note.pageObject;
+
+import static java.lang.Thread.sleep;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+import com.jorgeacetozi.notepad.note.domain.model.Note;
+
+public class NewNotePage {
+
+	@FindBy(id="newNote")
+	private WebElement newNoteModal;
+	
+	@FindBy(id="newNoteTitle")
+	private WebElement title;
+	
+	@FindBy(id="newNoteContent")
+	private WebElement content;
+	
+	@FindBy(id="btnCreateNewNote")
+	private WebElement createNoteButton;
+	
+	private Long sleep = 2000l;
+	
+	private WebDriver driver;
+	
+    public NewNotePage(WebDriver driver) {
+    	this.driver = driver;
+        PageFactory.initElements(driver, this);
+    }
+	
+	public void create(Note newNote) throws InterruptedException {
+		newNoteModal.click();
+		sleep(sleep);
+		
+		title.sendKeys(newNote.getTitle());
+		content.sendKeys(newNote.getContent());
+		createNoteButton.click();
+		sleep(sleep);
+	}
+
+	public String getMessage() {
+		return driver.findElement(By.className("noty_text")).getText();
+	}
+}


### PR DESCRIPTION
# Changelog
- Create an Acceptance Test that inserts a new note and verify the success message
- Create a new Maven profile for running Acceptance tests by issuing `mvn clean test -Pacceptance-tests` (it uses the `maven-surefire-plugin` to invoke JUnit tests)

# Flow
Basically, Maven will invoke the acceptance tests providing some java properties at runtime. These properties are: `acceptance.notepad.url` , `selenium.browser` and `surefire.rerunFailingTestsCount`. This allows to run the acceptance tests against any environment just informing the appropriate `acceptance.notepad.url`.