### PR TITLE
Add field subtitle to the Note

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM openjdk:8-alpine
 
 # File Author / Maintainer
-MAINTAINER Jorge Acetozi
+MAINTAINER Roussel Kamaha
 
 # Define default environment variables
 ENV NOTEPAD_HOME=/opt/notepad

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.jorgeacetozi</groupId>
 	<artifactId>notepad</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.0</version>
 	<packaging>jar</packaging>
 
 	<name>notepad</name>
@@ -31,7 +30,7 @@
 		<connection>scm:git:git@github.com:kamaha12000/notepad.git</connection>
 		<developerConnection>scm:git:git@github.com:kamaha12000/notepad.git</developerConnection>
 		<url>scm:git:git@github.com:kamaha12000/notepad.git</url>
-		<tag>HEAD</tag>
+		<tag>notepad-1.0.0</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.jorgeacetozi</groupId>
 	<artifactId>notepad</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>notepad</name>
@@ -30,7 +30,7 @@
 		<connection>scm:git:git@github.com:kamaha12000/notepad.git</connection>
 		<developerConnection>scm:git:git@github.com:kamaha12000/notepad.git</developerConnection>
 		<url>scm:git:git@github.com:kamaha12000/notepad.git</url>
-		<tag>notepad-1.0.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
 	</properties>
 
 	<scm>
-		<connection>scm:git:git@github.com:jorgeacetozi/notepad.git</connection>
-		<developerConnection>scm:git:git@github.com:jorgeacetozi/notepad.git</developerConnection>
-		<url>scm:git:git@github.com:jorgeacetozi/notepad.git</url>
+		<connection>scm:git:git@github.com:kamaha12000/notepad.git</connection>
+		<developerConnection>scm:git:git@github.com:kamaha12000/notepad.git</developerConnection>
+		<url>scm:git:git@github.com:kamaha12000/notepad.git</url>
 		<tag>HEAD</tag>
 	</scm>
 


### PR DESCRIPTION
# Changelog
**Branch**: `add-note-subtitle`

- Add `subtitle` attribute to `Node.java` model class
- Create database migration adding the column `subtitle` to table `note`
- Create new automated tests to ensure the field `subtitle` is optional
- Update the view to include the `subtitle` input.

# Tests
- [x] Adding a note with `title` and `content` should work.
- [x] Adding a note with `title`, `subtitle` and `content` should work
- [x] Any other combination should raise an error message